### PR TITLE
Use CPU to generate PerlinPowerFractal for eulerperlin sampler

### DIFF
--- a/utils/noise.py
+++ b/utils/noise.py
@@ -19,7 +19,7 @@ def perlin_masks(batch_size: int, width: int, height: int, device=None, seed: in
     
     c = PerlinPowerFractal(width, height)
     masks = c.forward(batch_size, 0, 0, 0, 0, device=torch.device("cpu"), seed=seed, scale=scale, **kwargs)
-    masks.to(device)
+    masks = masks.to(device)
 
     # return shape is [B, H, W, 1]
     return masks

--- a/utils/noise.py
+++ b/utils/noise.py
@@ -18,7 +18,8 @@ def perlin_masks(batch_size: int, width: int, height: int, device=None, seed: in
         device = comfy.model_management.get_torch_device()
     
     c = PerlinPowerFractal(width, height)
-    masks = c.forward(batch_size, 0, 0, 0, 0, device=device, seed=seed, scale=scale, **kwargs)
+    masks = c.forward(batch_size, 0, 0, 0, 0, device=torch.device("cpu"), seed=seed, scale=scale, **kwargs)
+    masks.to(device)
 
     # return shape is [B, H, W, 1]
     return masks


### PR DESCRIPTION
I don't know why this occurs but I get a bunch of

```plaintext
/build/intel-pytorch-extension/csrc/gpu/aten/operators/Indexing.h:670: operator(): global id: [9,0,0], local id: [9,0,0] Assertion `index >= -sizes[i] && index < sizes[i] && "index
 out of bounds"` failed                                                                                                                                                             
/build/intel-pytorch-extension/csrc/gpu/aten/operators/Indexing.h:670: operator(): global id: [10,0,0], local id: [10,0,0] Assertion `index >= -sizes[i] && index < sizes[i] && "ind
ex out of bounds"` failed 
```

and an actual total crash if I use any `eulerperlin` sampler mode except `matched_noise`. Probably just something weird with Intel, but this small change fixes it - generate the Perlin noise on CPU and then move it to the device afterward. I tested with 20 steps and a 2048x2048 sized empty latent and the `forward()` call took about 0.5 sec so I don't think there's a noticeable performance impact. I'm not sure moving it to the device is even necessary because it didn't seem to change the performance but it probably doesn't hurt.

Note: I have 0 clue what I am doing here, I just flailed around until I found something that fixed the issue. Thanks for making these nodes, very useful!