### PR TITLE
Update PyProject Toml - License

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "comfyui-iterative-mixer"
 description = "Implements a novel sampling approach that progressively blends noised latents to better align with a source image."
 version = "0.7.2"
-license = "LICENSE"
+license = { file = "LICENSE" }
 dependencies = ["torch>=2.0.0", "torchvision>=0.15.0", "comfy>=0.1.0", "numpy>=1.21.0", "matplotlib>=3.5.0", "Pillow>=9.0.0", "tqdm>=4.62.0", "scipy>=1.7.0"]
 
 [project.urls]


### PR DESCRIPTION
Hey! Robin from [comfy.org](https://comfy.org/) again 😊.

As a heads up, the `license` field is **optional** but in the case that it is filled out, the license file should be referenced either by the file path or by the name of the license.
- `license = { file = "LICENSE" }` ✅
- `license = {text = "MIT License"}` ✅
- `license = "LICENSE"` ❌
- `license = "MIT LICENSE"` ❌

This was brought up in our discord and so we're creating a small PR to update that optional field. For more info check out toml file [standards](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) or our [docs](https://docs.comfy.org/registry/specifications#license) page!